### PR TITLE
Update CSS template for docs reference

### DIFF
--- a/reference/docs/template/public/main.css
+++ b/reference/docs/template/public/main.css
@@ -1,1 +1,1 @@
-@import "workflow.css";
+@import "bonsai.css";


### PR DESCRIPTION
The name of the CSS template file in the updated docfx-tools module has been renamed, so we rename the reference accordingly.