### PR TITLE
Move index page into the documentation section

### DIFF
--- a/reference/docs/articles/toc.yml
+++ b/reference/docs/articles/toc.yml
@@ -1,0 +1,2 @@
+- name: Introduction
+  href: ../index.md

--- a/reference/docs/index.md
+++ b/reference/docs/index.md
@@ -1,5 +1,1 @@
----
-_layout: landing
----
-
 [!INCLUDE [](README.md)]

--- a/reference/docs/toc.yml
+++ b/reference/docs/toc.yml
@@ -1,2 +1,4 @@
+- name: Documentation
+  href: articles/
 - name: API
   href: ../artifacts/docs/api/


### PR DESCRIPTION
The aim is both to provide a better starting reference on how to structure conceptual documentation, and improve navigation experience.

New lines at the end of `toc.yml` files have been removed for consistency with other project repos.

Fixes #39 