### PR TITLE
Allow net48 target framework in csproj

### DIFF
--- a/src/Prefect/#Rules/CSharpProjectValidationRule.cs
+++ b/src/Prefect/#Rules/CSharpProjectValidationRule.cs
@@ -78,7 +78,7 @@ internal sealed class CSharpProjectValidationRule : Rule
     [
         "net462",
         "net472",
-        //"net48", // Only Bonsai's bootstrapper should be using .NET 4.8
+        "net48",
         "netstandard2.0",
         "net8.0",
         "net8.0-windows",


### PR DESCRIPTION
This can rarely be required for driver compatibility. Since the bootstrapper runs on net48, this target should be allowed.

Fixes #35 