### PR TITLE
Avoid end of line normalization on shell scripts

### DIFF
--- a/reference/.gitattributes
+++ b/reference/.gitattributes
@@ -3,6 +3,7 @@
 
 # Scripts
 *.cmd text eol=crlf
+*.sh text eol=lf
 *.ps1 text
 
 # Config


### PR DESCRIPTION
This is important to avoid modifying shell script permissions on Windows machines.

Fixes #29 