### PR TITLE
Configure build for building documentation job

### DIFF
--- a/reference/.github/workflows/$PROJECT$.yml
+++ b/reference/.github/workflows/$PROJECT$.yml
@@ -133,6 +133,11 @@ jobs:
       - name: Set up .NET tools
         run: dotnet tool restore
 
+      # ----------------------------------------------------------------------- Configure build
+      - name: Configure build
+        id: configure-build
+        uses: bonsai-rx/configure-build@v1
+
       # ----------------------------------------------------------------------- Restore
       - name: Restore
         run: dotnet restore


### PR DESCRIPTION
This will ensure Roslyn picks up any required outputs such as T4 code generation artifacts and also removes warnings related to missing properties.

Fixes #12 