### PR TITLE
Search for favicon and logo in template path

### DIFF
--- a/reference/docs/docfx.json
+++ b/reference/docs/docfx.json
@@ -39,10 +39,6 @@
           "workflows/**/*.{bonsai,svg}",
           "{articles,tutorials,examples}/**/*.{bonsai,svg}"
         ]
-      },
-      {
-        "src": "../build/",
-        "files": "icon.png"
       }
     ],
     "overwrite": [
@@ -62,8 +58,6 @@
       "_appName": "$PROJECT$",
       "_appTitle": "$PROJECT$",
       "_appFooter": "&copy; Bonsai Foundation CIC and Contributors. Made with <a href=\"https://dotnet.github.io/docfx\">docfx</a>",
-      "_appLogoPath": "logo.svg",
-      "_appFaviconPath": "icon.png",
       "_enableNewTab": true,
       "_enableSearch": true,
       "_gitContribute": {


### PR DESCRIPTION
By default docfx looks for both the favicon and logo in specific paths inside the template. These are provided by the shared docfx tools repo so we do not need to override them.

This also enables downstream repos to apply their own shared templates by forking the base [bonsai-rx/docfx-tools](https://github.com/bonsai-rx/docfx-tools) repo.

Fixes #20 