### PR TITLE
Update all available actions to node24

### DIFF
--- a/reference-harp/.github/workflows/$PROJECT$.yml
+++ b/reference-harp/.github/workflows/$PROJECT$.yml
@@ -28,11 +28,11 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # ----------------------------------------------------------------------- Set up tools
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
@@ -65,7 +65,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect NuGet packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: matrix.collect-packages && steps.pack.outcome == 'success' && always()
         with:
           name: Packages
@@ -84,13 +84,13 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Set up .NET
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       # ----------------------------------------------------------------------- Download built packages
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: artifacts/packages/

--- a/reference/.github/workflows/$PROJECT$.yml
+++ b/reference/.github/workflows/$PROJECT$.yml
@@ -62,20 +62,20 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       # ----------------------------------------------------------------------- Set up tools
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       # ----------------------------------------------------------------------- Configure build
       - name: Configure build
         id: configure-build
-        uses: bonsai-rx/configure-build@v1
+        uses: bonsai-rx/configure-build@v2
 
       # ----------------------------------------------------------------------- Build
       - name: Restore
@@ -100,7 +100,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect NuGet packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: matrix.collect-packages && steps.pack.outcome == 'success' && always()
         with:
           name: Packages
@@ -120,13 +120,13 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       # ----------------------------------------------------------------------- Set up tools
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
@@ -149,7 +149,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect documentation metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.build-metadata.outcome == 'success' && always()
         with:
           name: DocumentationMetadata
@@ -157,7 +157,7 @@ jobs:
           path: artifacts/docs/api/
 
       - name: Collect documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.build-documentation.outcome == 'success' && always()
         with:
           name: DocumentationWebsite
@@ -180,20 +180,20 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       # ----------------------------------------------------------------------- Download built packages
       - name: Download packages for rendering
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: artifacts/packages/
 
       # ----------------------------------------------------------------------- Set up Bonsai environments
       - name: Set up Bonsai environments
-        uses: bonsai-rx/setup-bonsai@v1
+        uses: bonsai-rx/setup-bonsai@v2
         with:
           environment-paths: '**/.bonsai/'
           inject-packages: artifacts/packages/*.nupkg
@@ -205,7 +205,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.render.outcome == 'success' && always()
         with:
           name: DocumentationWorkflowImages
@@ -233,13 +233,13 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Set up .NET
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       # ----------------------------------------------------------------------- Download built packages
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: artifacts/packages/
@@ -275,13 +275,13 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Set up .NET
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       # ----------------------------------------------------------------------- Download built packages
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: artifacts/packages/
@@ -326,23 +326,23 @@ jobs:
       # It is intentional that we use two independent download steps here as it ensures that workflow images are permitted
       # to overwrite any conflicts in the docfx output but not the other way around.
       - name: Download documentation website
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DocumentationWebsite
 
       - name: Download workflow images
         if: ${{needs.workflow-images.result == 'success'}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DocumentationWorkflowImages
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Upload final documentation website artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: '.'
 
       # ----------------------------------------------------------------------- Publish to GitHub Pages
       - name: Publish to GitHub Pages
         id: publish
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
This updates all GitHub Actions in the `reference` and `reference-harp` templates to their current majors, which run on node24: `checkout@v7`, `setup-dotnet@v5`, `upload-artifact@v7`, and `download-artifact@v8`, plus `upload-pages-artifact@v5` and `deploy-pages@v5` in `reference`. It also moves the `bonsai-rx` composites to `@v2`, now that `setup-bonsai` and `configure-build` run on node24.

Fixes #48