### PR TITLE
Bump configure-build to v2 in build-documentation

### DIFF
--- a/reference/.github/workflows/$PROJECT$.yml
+++ b/reference/.github/workflows/$PROJECT$.yml
@@ -136,7 +136,7 @@ jobs:
       # ----------------------------------------------------------------------- Configure build
       - name: Configure build
         id: configure-build
-        uses: bonsai-rx/configure-build@v1
+        uses: bonsai-rx/configure-build@v2
 
       # ----------------------------------------------------------------------- Restore
       - name: Restore


### PR DESCRIPTION
This step was added after #49 originally branched, so it merged still on v1 while the rest moved to v2.
