### PR TITLE
Add editorconfig rules for YAML files

### DIFF
--- a/reference/.editorconfig
+++ b/reference/.editorconfig
@@ -4,13 +4,17 @@ root = true
 indent_style = space
 
 #--------------------------------------------------------------------------------------------------
-# XML, JSON, and web files
+# XML, JSON, YAML, and web files
 #--------------------------------------------------------------------------------------------------
 [*.{xml,csproj,vcxproj,vcxproj.filters,shproj,props,targets,config,nuspec,resx,vsixmanifest,wxs,vstemplate,slnx}]
 indent_size = 2
 
 [*.json]
 indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+charset = utf-8
 
 [*.{html,css}]
 indent_size = 2


### PR DESCRIPTION
YAML files (.yml, .yaml) have no matching section in the reference `.editorconfig`, so they fall through to `[*]`, which sets only `indent_style = space`. The XML glob would cover indentation if extended, but not `charset`, and YAML must be UTF-8 without a BOM since a BOM is rejected or mishandled by many parsers. This PR adds a YAML glob to the config-and-data block that pins two-space indentation and a BOM-free charset.

`indent_size = 2` matches the two-space convention used by the reference's own YAML, the GitHub Actions workflow and the docfx `toc.yml` and `filter.yml`, with `device.yml` on top for Harp devices. `charset = utf-8` is why YAML needs its own glob rather than joining the shared XML glob: it guarantees no BOM, the opposite of the `utf-8-bom` used by the C# and C++ blocks where a BOM is wanted.

`trim_trailing_whitespace` and `insert_final_newline` are left unset to match the other config-and-data globs rather than over-pinning the format, and line endings are left to `.gitattributes` as with the other blocks.

Closes #56